### PR TITLE
Test workflow

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -14,7 +14,9 @@
         "releaseRules": [
             {"type": "release","release": "patch"}
     ]}],
-    "@semantic-release/release-notes-generator"
+  ],
+   "generateNotes": [
+      "@semantic-release/release-notes-generator"
   ],
   "prepare": [
     "@semantic-release/changelog",


### PR DESCRIPTION
move the release-notes-generator to the right step in semantic-release