### PR TITLE
Upgrade dependencies to use ibm-cloud-sdk-core ^4.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "extend": "^3.0.2",
-    "ibm-cloud-sdk-core": "^4.2.2"
+    "ibm-cloud-sdk-core": "^4.3.3"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
This new version of ibm-cloud-sdk-core uses the much more recent ^27.5.1 version of expect, hence resolving these 2 CVEs.
+ [CVE-2024-4067](https://www.mend.io/vulnerability-database/CVE-2024-4067)
+ [CVE-2024-4068](https://www.mend.io/vulnerability-database/CVE-2024-4068)